### PR TITLE
Complete the kmachine formula

### DIFF
--- a/kmachine.rb
+++ b/kmachine.rb
@@ -1,13 +1,31 @@
 class Kmachine < Formula
   desc "Single Node Kubernetes cluster"
   homepage "http://www.skippbox.com"
-  url "https://github.com/skippbox/kmachine/releases/download/v1.2.0-alpha.8/kmachine_darwin-amd64.tar.gz"
-  sha256 "6678be23c2954ce0eeb589b446f0aec55bcbaa59e937d4aee5bb5d58995caf00"
+  version "0.5.0"
+
+  if MacOS.prefer_64_bit?
+    url "https://github.com/skippbox/kmachine/releases/download/v1.2.0-alpha.8/kmachine_darwin-amd64.tar.gz"
+    sha256 "6678be23c2954ce0eeb589b446f0aec55bcbaa59e937d4aee5bb5d58995caf00"
+  else
+    url "https://github.com/skippbox/kmachine/releases/download/v1.2.0-alpha.8/kmachine_darwin-386.tar.gz"
+    sha256 "1sdrsjc1fbmikh0h3cms882n8x8xc1n7ga027780k5hz1lbyfmsg"
+  end
+
+  def caveats; <<-EOS.undent
+    To use kmachine on your local computer, you will need to have
+    Virtualbox installed. Please install it from:
+      https://www.virtualbox.org/wiki/Downloads
+    EOS
+  end
+
+  bottle :unneeded
 
   def install
     bin.install "kmachine"
+    bin.install Dir["kmachine-driver*"]
   end
 
   test do
+    system "kmachine", "-v"
   end
 end

--- a/kmachine.rb
+++ b/kmachine.rb
@@ -8,7 +8,7 @@ class Kmachine < Formula
     sha256 "6678be23c2954ce0eeb589b446f0aec55bcbaa59e937d4aee5bb5d58995caf00"
   else
     url "https://github.com/skippbox/kmachine/releases/download/v1.2.0-alpha.8/kmachine_darwin-386.tar.gz"
-    sha256 "1sdrsjc1fbmikh0h3cms882n8x8xc1n7ga027780k5hz1lbyfmsg"
+    sha256 "4f57e7170d1f9609d03902a8776c601d75640542bab201019cb12e1798d4b9e9"
   end
 
   def caveats; <<-EOS.undent

--- a/kmachine.rb
+++ b/kmachine.rb
@@ -11,18 +11,18 @@ class Kmachine < Formula
     sha256 "4f57e7170d1f9609d03902a8776c601d75640542bab201019cb12e1798d4b9e9"
   end
 
-  def caveats; <<-EOS.undent
-    To use kmachine on your local computer, you will need to have
-    Virtualbox installed. Please install it from:
-      https://www.virtualbox.org/wiki/Downloads
-    EOS
-  end
-
   bottle :unneeded
 
   def install
     bin.install "kmachine"
     bin.install Dir["kmachine-driver*"]
+  end
+
+  def caveats; <<-EOS.undent
+    To use kmachine on your local computer, you will need to have
+    Virtualbox installed. Please install it from:
+      https://www.virtualbox.org/wiki/Downloads
+    EOS
   end
 
   test do


### PR DESCRIPTION
Here is a more complete kmachine formula distributing binary only (with a selection for 32/64bit OS X)

2 things that need info from you @runseb:
- [ ] What is the actual version of the tool? The URL say `1.2.0-alpha.8`, but `kmachine -v` return `0.5.0`
- [ ] The test is pretty light (but acceptable for homebrew standard). Possible improvement would be to run a command that test some functionality, but that don't take too much time to run. Is there a way to make a dry-run of launching a kubernetes cluster? That would make a nice test.

Sadly it seems there is no clean way to depend on an external software, so the only way to warn about the VirtualBox dependency is to use the `caveats` function, that will print at installation time.
