### PR TITLE
Adding a Homebrew Cask formual for Skippbox

### DIFF
--- a/Casks/skippbox.rb
+++ b/Casks/skippbox.rb
@@ -1,0 +1,18 @@
+cask 'skippbox' do
+  name 'Skippbox'
+  version '0.0.1'
+  homepage 'https://skippbox.com'
+  license :apache
+
+  if Hardware::CPU.is_64_bit?
+    url "https://github.com/skippbox/skippbox/releases/download/v0.0.1/osx64.tar.gz"
+    sha256 'ca2be4e3b088cf41fef88c0ffa8e7ccc4b4321f31f9017833412e4e33dc2db3c'
+    path = 'osx64'
+  else
+    url "https://github.com/skippbox/skippbox/releases/download/v0.0.1/osx32.tar.gz"
+    sha256 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    path = 'osx32'
+  end
+
+  app "#{path}/skippbox.app"
+end

--- a/README.md
+++ b/README.md
@@ -13,3 +13,8 @@ Or add the Skippbox tap to your Homebrew installation:
     $ brew tap skippbox/tap
     $ brew install kmachine
 
+GUI apps (like Skippbox), will need Homebrew Cask to be installed to works (asuming you added our tap as demonstrated in the previous steps:
+
+    $ brew tap caskroom/cask
+    $ brew cask install skippbox
+

--- a/UPDATE_FORMULA.md
+++ b/UPDATE_FORMULA.md
@@ -21,6 +21,16 @@ If the installation goes well, you can test and audit the formula for styling (j
 
 And you are done :)
 
+## OS X application bundle (.app)
+
+Those applications are rejected in Homebrew, a specific project exist
+for that: [Homebrew Cask](https://github.com/caskroom/homebrew-cask)
+
+The formulae are sensibly the same, but you need to put those in the `Casks`
+folder and use the `brew cask` command:
+
+    $ brew cask install skippbox
+
 ## Resources
 
 Nice to have resources on hombrew.
@@ -28,3 +38,4 @@ Nice to have resources on hombrew.
  - [Formula Cookbook](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Formula-Cookbook.md)
  - [Common Issues](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Common-Issues.md)
  - [Homebrew FAQ](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/FAQ.md)
+ - [Homebrew Cask contribution guide](https://github.com/caskroom/homebrew-cask/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
This commit add a formula for Skippbox.

By default Homebrew does not permit to install .app in `~/Applications`, to do  that you have to use [Homebrew Cask](https://github.com/caskroom/homebrew-cask).

I have added related information in the README and UPDATE_FORMULA files.
